### PR TITLE
Update Machine names to match scarthgap machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ export MACHINE=ov-cb2-ch70
 ```
 bitbake openvario-image
 ```
+
+If the build fails, try checking out the `scarthgap` branch in `meta-openvario`, as it may resolve the issue. If the problem persists, please open an issue so we can investigate it.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ source openembedded-core/oe-init-build-env .
 ### Setting the machine
 
 ```
-export MACHINE=openvario-7-CH070
+export MACHINE=ov-cb2-ch70
 ```
 
 ### Available machines for the OpenVario 
@@ -49,24 +49,23 @@ export MACHINE=openvario-7-CH070
     Cubieboard 2 and the original adapter board
     ===========================================
 
-    ov-cb2-43-rgb
-    ov-cb2-57-lvds
-    ov-cb2-7-ch070
-    ov-cb2-7-pq070
+    ov-cb2-am43
+    ov-cb2-ch57
+    ov-cb2-ch70
+    ov-cb2-pq70
   
     Cubieboard 2 and the adapter board DS2
     ======================================
 
-    ov-cb2-57-lvds-ds2
-    ov-cb2-7-am070-ds2
-    ov-cb2-7-ch070-ds2
-    ov-cb2-7-pq070-ds2
+    ov-cb2-am70s
+    ov-cb2-ch57s
+    ov-cb2-ch70s
 
     Raspberry Pi CM4 (testing status)
     =================================
     
-    ov-cm4-7-pq070
-    ov-cm4-57-lvds
+    ov-cm4-ch57
+    ov-cm4-pq70
 
     ov-rpi4 (developemt only)
     ov-rpi4-64 (development only)


### PR DESCRIPTION
Machine names have been reorganized in Openvario/meta-openvario#402, specifically in [5f72064](https://github.com/Openvario/meta-openvario/commit/5f7206441f6255489d27e2035074775dffc9b225).
Addresses Openvario/meta-openvario#423