### PR TITLE
chore: add issue template to mention where to place issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,16 @@
+name: Bug Report
+description: Report a problem with the OpenVario build system or repository setup
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please do not report issues related to the meta-openvario layer in this repository. Those issues should be opened in the [Openvario/meta-openvario](https://github.com/Openvario/meta-openvario/issues) repository instead.
+  - type: input
+    id: contact
+    attributes:
+      label: Describe your issue
+      description: Thank you for helping improve OpenVario. Please provide as much detail as possible so the issue can be triaged quickly.
+      placeholder:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Two new issues have been created in this repo. It might be not that clear, that you should open an issue in the meta-openvario repo.
It is possible to clarify it in the template even more by naming the template do not create an issue here.